### PR TITLE
Adjust code in documentation to the spec

### DIFF
--- a/website/docs/r/acm_certificate.html.markdown
+++ b/website/docs/r/acm_certificate.html.markdown
@@ -46,7 +46,7 @@ resource "aws_route53_record" "cert_validation" {
 
 resource "aws_acm_certificate_validation" "cert" {
   certificate_arn = "${aws_acm_certificate.cert.certificate_arn}"
-  validation_record_fqdn = "${aws_route53_record.cert_validation.fqdn}"
+  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
 }
 
 resource "aws_lb_listener" "front_end" {


### PR DESCRIPTION
Got error while using the new resource ```aws_acm_certificate_validation``` by copy and paste code in the documentation. It's fixed when it's written in the way in this PR. 